### PR TITLE
Re-add select inputs

### DIFF
--- a/lab5.srcs/sources_1/new/alu_testbench.v
+++ b/lab5.srcs/sources_1/new/alu_testbench.v
@@ -7,24 +7,28 @@ module alu_testbench();
     always #(2) clock <= ~clock;
     // Self test of the structural alu
     wire [13:0] alu_operand1, alu_operand2;
+    wire [1:0] alu_sel;
     wire [14:0] structural_alu_out, behavioral_alu_out;
     wire test_fail;
 
     structural_alu structural_test_alu (
         .a(alu_operand1),
         .b(alu_operand2),
+        .sel(alu_sel),
         .out(structural_alu_out)
     );
 
     behavioral_alu behavioral_test_alu (
         .a(alu_operand1),
         .b(alu_operand2),
+        .sel(alu_sel),
         .out(behavioral_alu_out)
     );
 
     alu_tester tester (
         .alu_operand1(alu_operand1),
         .alu_operand2(alu_operand2),
+        .sel(alu_sel),
         .structural_out(structural_alu_out),
         .behavioral_out(behavioral_alu_out),
         .clk(clock),

--- a/lab5.srcs/sources_1/new/alu_testbench.v
+++ b/lab5.srcs/sources_1/new/alu_testbench.v
@@ -28,7 +28,6 @@ module alu_testbench();
     alu_tester tester (
         .alu_operand1(alu_operand1),
         .alu_operand2(alu_operand2),
-        .sel(alu_sel),
         .structural_out(structural_alu_out),
         .behavioral_out(behavioral_alu_out),
         .clk(clock),

--- a/lab5.srcs/sources_1/new/alu_tester.v
+++ b/lab5.srcs/sources_1/new/alu_tester.v
@@ -1,9 +1,9 @@
 module alu_tester (
     output [13:0] alu_operand1,
     output [13:0] alu_operand2,
+    input [1:0] sel,
     input [14:0] structural_alu_out,
     input [14:0] behavioral_alu_out,
-    input [1:0] sel,
     input clk,
     output test_fail
 );

--- a/lab5.srcs/sources_1/new/alu_tester.v
+++ b/lab5.srcs/sources_1/new/alu_tester.v
@@ -3,6 +3,7 @@ module alu_tester (
     output [13:0] alu_operand2,
     input [14:0] structural_alu_out,
     input [14:0] behavioral_alu_out,
+    input [1:0] sel,
     input clk,
     output test_fail
 );

--- a/lab5.srcs/sources_1/new/alu_tester.v
+++ b/lab5.srcs/sources_1/new/alu_tester.v
@@ -1,7 +1,6 @@
 module alu_tester (
     output [13:0] alu_operand1,
     output [13:0] alu_operand2,
-    input [1:0] sel,
     input [14:0] structural_alu_out,
     input [14:0] behavioral_alu_out,
     input clk,


### PR DESCRIPTION
When I deleted the extra files it clobbered these edits adding new select inputs to the ALU testbench and tester. These commits re-add them.